### PR TITLE
Fixed CRUD operations on secrets

### DIFF
--- a/plugins/kubernetes/html/secret.html
+++ b/plugins/kubernetes/html/secret.html
@@ -9,8 +9,27 @@
 
   <div class="row filter-header">
     <div class="col-md-12">
+
+      <button class="btn btn-danger pull-right"
+              title="Deletes the current secret"
+              ng-show="id"
+              ng-click="deletePrompt()">
+        <i class="fa fa-remove"></i> Delete
+      </button>
+      <span class="pull-right">&nbsp;</span>
+
+      <button class="btn btn-default pull-right" ng-click="goToList()">
+        <i class="fa fa-list"></i>
+      </button>
+
+      <span class="pull-right">&nbsp;</span>
+
+      <a class="btn btn-default pull-right" ng-show="id" ng-click="readOnly = !readOnly" ng-class="!readOnly ? 'btn-primary' : ''">Edit</a>
+      <span class="pull-right">&nbsp;</span>
+
       <button class="btn btn-default pull-right"
               title="Cancel changes to this secret"
+              ng-disabled="!entity.name || !changed"
               ng-click="cancel()">
         Cancel
       </button>
@@ -68,14 +87,14 @@
 
             <div class="col-sm-9" ng-switch="property.type">
               <textarea ng-switch-when="textarea" class="form-control" rows="{{property.rows}}" id="{{property.key}}" ng-change="entityChanged()"
-                        ng-model="entity.properties[property.key].value"></textarea>
+                        ng-model="entity.properties[property.key].value" ng-readonly="readOnly"></textarea>
               <input ng-switch-default="" type="{{property.type}}" class="form-control" id="{{property.key}}" ng-change="entityChanged()"
-                        ng-model="entity.properties[property.key].value">
+                        ng-model="entity.properties[property.key].value" ng-readonly="readOnly">
             </div>
 
             <div class="col-sm-1">
               <button class="btn btn-danger pull-right" ng-click="deleteProperty(property.key)"
-                      title="Remove this property from the secret">
+                      title="Remove this property from the secret" ng-hide="readOnly">
                 <i class="fa fa-remove"></i>
               </button>
             </div>
@@ -86,16 +105,16 @@
         <div class="form-group" ng-show="entity.name">
           <div class="col-sm-12">
             <div class="text-center">
-              <button class="btn btn-default btn-padding" ng-click="addFields(httpsKeys)" ng-hide="hasAllKeys(httpsKeys)"
+              <button class="btn btn-default btn-padding" ng-click="addFields(httpsKeys)" ng-hide="readOnly || hasAllKeys(httpsKeys)"
                       title="Adds fields to store HTTPS user and password fields">
                 <i class="fa fa-plus"></i> HTTPS User &amp; Password Fields
               </button>
-              <button class="btn btn-default btn-padding" ng-click="addFields(sshKeys)" ng-hide="hasAllKeys(sshKeys)"
+              <button class="btn btn-default btn-padding" ng-click="addFields(sshKeys)" ng-hide="readOnly || hasAllKeys(sshKeys)"
                       title="Adds the fields to store SSH private and public keys">
                 <i class="fa fa-plus"></i> SSH Key Fields
               </button>
               <button class="btn btn-default btn-padding" ng-click="addFieldDialog.dialog.open()"
-                      title="Adds a new data field to store new data in this secret">
+                      title="Adds a new data field to store new data in this secret" ng-hide="readOnly">
                 <i class="fa fa-plus"></i> Custom Field
               </button>
             </div>

--- a/plugins/kubernetes/ts/kubernetesPlugin.ts
+++ b/plugins/kubernetes/ts/kubernetesPlugin.ts
@@ -18,6 +18,7 @@ module Kubernetes {
       .when(UrlHelpers.join(context, 'replicationControllers'), route('replicationControllers.html', false))
       .when(UrlHelpers.join(context, 'services'), route('services.html', false))
       .when(UrlHelpers.join(context, 'events'), route('events.html', false))
+      .when(UrlHelpers.join(context, 'secrets'), route('secrets.html', false))
       .when(UrlHelpers.join(context, 'apps'), route('apps.html', false))
       .when(UrlHelpers.join(context, 'apps/:namespace'), route('apps.html', false))
       .when(UrlHelpers.join(context, 'hosts'), route('hosts.html', false))
@@ -28,10 +29,10 @@ module Kubernetes {
 
   // Put kubernetes views under all of these contexts
   angular.forEach([
-        context, 
-        "/workspaces/:workspace/projects/:project", 
+        context,
+        "/workspaces/:workspace/projects/:project",
         "/workspaces/:workspace"
-      ], 
+      ],
       (context) => {
         $routeProvider
       .when(UrlHelpers.join(context, '/namespace/:namespace/podCreate'), route('podCreate.html', false))


### PR DESCRIPTION
Taking the suggestions at https://github.com/fabric8io/fabric8-console/issues/96, I fixed the screens that allow making CRUD operations on secrets.

What I made:
- access to a secret defaults to read-only mode
- added the edit button as in the pods screen
- cancel and save now are enabled and disabled correctly
- added button to go back to the list
- added delete button (with confirmation)

I tested the following workflows:
- from the list of secrets -> edit
- from the list of secrets -> add
- from the list of secrets -> edit then delete
- from application settings -> create secret -> save/back

I don't know if there are other user flows related to secrets.
